### PR TITLE
Allow functions and typedefs to be declared after use (in upper scope…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+.idea/

--- a/typescript.js
+++ b/typescript.js
@@ -30,7 +30,7 @@ module.exports = {
         "@typescript-eslint/interface-name-prefix": "off",
         "@typescript-eslint/prefer-interface": "off",
         
-        "@typescript-eslint/no-use-before-define": [ "warn", { "functions": false, "classes": false } ],
+        "@typescript-eslint/no-use-before-define": [ "error", { "functions": false, "classes": false, "variables": false, "typedefs": false } ],
 
         "@typescript-eslint/member-delimiter-style": ["error", { "multiline": { "delimiter": "none" }, "singleline": { "delimiter": "comma" } }],
         "@typescript-eslint/type-annotation-spacing": ["error", { "before": false, "after": true, "overrides": { "arrow": { "before": true, "after": true }} }],


### PR DESCRIPTION
Allow functions and typedefs to be declared after use (in upper scope only).

This means that it still picks up the definite errors, while still allowing us to define stuff after use, as long as the usage is in a lower scope.