### PR TITLE
add support for typescript eslint v5 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
         "url": "git+https://github.com/tfso/eslint-config-tfso.git"
     },
     "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^2 || ^3 || ^4",
-        "@typescript-eslint/parser": "^2 || ^3 || ^4",
+        "@typescript-eslint/eslint-plugin": "^2 || ^3 || ^4 || ^5",
+        "@typescript-eslint/parser": "^2 || ^3 || ^4 || ^5",
         "eslint": "^6 || ^7",
         "eslint-config-react-app": "^5 || ^6",
         "eslint-plugin-react": "^7",


### PR DESCRIPTION
### Support typescript-eslint v5
Renovate discovers a conflicting peer dependency when it tries to update dependencies for repositories that both use eslint-config-tfso and tysecript-eslint v5.x.y. This is (likely?) caused by eslint-config-tfso only supporting typescript-eslint versions up to 4. See example here: https://github.com/tfso/api-product/pull/188

The changelog from typescript-eslint v4 to v5 only has one breaking change which doesn't seem to affect us, so I don't see any problems with allowing v5 as well.

**Changelog typescript-eslint V5.0.0**: https://github.com/typescript-eslint/typescript-eslint/blob/main/CHANGELOG.md#500-2021-10-11